### PR TITLE
BugFixes for C++ Code Generation

### DIFF
--- a/control/trajectory/section/trajSectionGetArcLength.m
+++ b/control/trajectory/section/trajSectionGetArcLength.m
@@ -50,12 +50,12 @@ dy = polyder(traj_section.pos_y);
 dz = polyder(traj_section.pos_z);
 
 % Function handle of the arc length derivative
-arc_length_fun = @(ts) sqrt( polyval(dx, ts).^2 + ...
-                             polyval(dy, ts).^2 + ...
-                             polyval(dz, ts).^2);                       
+arc_length_fun = @(ts) sqrt( polyVal(dx, ts).^2 + ...
+                             polyVal(dy, ts).^2 + ...
+                             polyVal(dz, ts).^2);                       
 
 % Numerical integration of the arc length derivative from [0, t]
-arc_length = quadgk(arc_length_fun, 0, t);
+arc_length = integralSimpson(arc_length_fun, 0, t, 15);
 
 % Return the arc length derivative
 arc_length_dt = arc_length_fun(t);

--- a/control/trajectory/section/trajSectionGetDerivatives.m
+++ b/control/trajectory/section/trajSectionGetDerivatives.m
@@ -51,18 +51,18 @@ dy = polyder(traj_section.pos_y);
 % Derivative of z position
 dz = polyder(traj_section.pos_z);
 
-first_deriv = [polyval(dx, t); polyval(dy, t); polyval(dz, t)];
+first_deriv = [polyVal(dx, t); polyVal(dy, t); polyVal(dz, t)];
 
 % Calculate second derivative of path
 ddx = polyder(dx);
 ddy = polyder(dy);
 ddz = polyder(dz);
-sec_deriv = [polyval(ddx, t); polyval(ddy, t); polyval(ddz, t)];
+sec_deriv = [polyVal(ddx, t); polyVal(ddy, t); polyVal(ddz, t)];
 
 % Calculate third derivative of path
 dddx = polyder(ddx);
 dddy = polyder(ddy);
 dddz = polyder(ddz);
-third_deriv = [polyval(dddx, t); polyval(dddy, t); polyval(dddz, t)];
+third_deriv = [polyVal(dddx, t); polyVal(dddy, t); polyVal(dddz, t)];
 
 end

--- a/control/trajectory/section/trajSectionGetPos.m
+++ b/control/trajectory/section/trajSectionGetPos.m
@@ -36,13 +36,13 @@ else
 end    
 
 % Calculate x-positon with t
-px = polyval(traj_section.pos_x, t);
+px = polyVal(traj_section.pos_x, t);
 
 % Calculate y-positon with t
-py = polyval(traj_section.pos_y, t);
+py = polyVal(traj_section.pos_y, t);
 
 % Calculate z-positon with t
-pz = polyval(traj_section.pos_z, t);
+pz = polyVal(traj_section.pos_z, t);
 
 % return position vector
 pos = [px; py; pz];

--- a/control/trajectory/spline_functions/polyInterpolation.m
+++ b/control/trajectory/spline_functions/polyInterpolation.m
@@ -174,7 +174,7 @@ for k = 1:(num_of_splines-1)
 end
     
 % Solve the System
-coeffs = A \ b;
+coeffs = (A \ b)';
 
 %% Plot function and derivatives
 if(plot_enable)

--- a/control/trajectory/spline_functions/polyInterpolation.m
+++ b/control/trajectory/spline_functions/polyInterpolation.m
@@ -79,8 +79,8 @@ bnd_med = degree;
 intermediate_size = sub_mat_size*(num_of_splines-1);
 
 size_A_mat = sub_mat_size*num_of_splines;
-A = sparse(size_A_mat, size_A_mat);
-b = sparse(size_A_mat, 1);
+A = zeros(size_A_mat, size_A_mat);
+b = zeros(size_A_mat, 1);
 
 if cycle == false
     
@@ -174,12 +174,11 @@ for k = 1:(num_of_splines-1)
 end
     
 % Solve the System
-x = A \ b;
-coeffs = full(x)';
+coeffs = A \ b;
+
 %% Plot function and derivatives
 if(plot_enable)
     
-    figure(1)
     clf;
     subplot(derivatives+1, 1, 1)
     hold on
@@ -188,7 +187,7 @@ if(plot_enable)
         idx_beg = sub_mat_size*(i-1)+1;
         idx_end = sub_mat_size*(i);
         x_iter  = coeffs(idx_beg:idx_end);
-        plot(i-1:0.01:i,polyval(x_iter,0:0.01:1))
+        plot(i-1:0.01:i,polyVal(x_iter,0:0.01:1))
     end
     hold off
     grid on
@@ -208,7 +207,7 @@ if(plot_enable)
                 x_derivative = polyder(x_derivative);
             end
             
-            plot(i-1:0.01:i,polyval(x_derivative,0:0.01:1))
+            plot(i-1:0.01:i,polyVal(x_derivative,0:0.01:1))
         end
         hold off
         grid on

--- a/control/trajectory/trajGetMatch.m
+++ b/control/trajectory/trajGetMatch.m
@@ -186,13 +186,13 @@ for k = first_checked_section:last_checked_section
     %% trajGetError
     
     % Calculate x-positon with t
-    px = polyval(traj_section.pos_x, T');
+    px = polyVal(traj_section.pos_x, T');
     
     % Calculate y-positon with t
-    py = polyval(traj_section.pos_y, T');
+    py = polyVal(traj_section.pos_y, T');
     
     % Calculate z-positon with t
-    pz = polyval(traj_section.pos_z, T');
+    pz = polyVal(traj_section.pos_z, T');
     
     % return position vector
     curr_pos = [px; py; pz];

--- a/control/trajectory/trajGetMatchOrder5.m
+++ b/control/trajectory/trajGetMatchOrder5.m
@@ -1,0 +1,147 @@
+function [section_idx, error_sqr, t] = trajGetMatchOrder5(traj, position, active_section)
+% trajGetMatchOrder5 computes the nearest point on the trajectory
+%   The function returns the point on the trajectory that has minimum
+%   euclidean norm in respect to the given position.
+%   This function only works with a polynominal degree of five.
+%
+% Inputs:
+%   traj            trajectory struct, see trajInit
+%
+%   position        vehicle position [x; y; z] in local geodetic
+%                   coordinate system
+%                   (3x1 vector), in m
+%
+%   active_section 	*placeholder for later use*
+%                   current section of the trajectory
+%                  	(scalar), dimensionless
+% Outputs:
+%
+%   section_idx     index of the trajectory section that contains the point
+%                   of minimum eulidean distance
+%
+%   error           the minimum euclidean distance between the given
+%                   position and the trajectory
+%                   (scalar), in m
+%
+%   t               dimensionless time parameter that correnspons to the
+%                   trajectory point of minimum eulidean distance
+%                	(scalar), [0-1]
+%
+% Syntax:
+%   [section_idx, error, t] = trajGetMatch(traj, position, active_section)
+%
+% See also: trajGetMatch, trajCreateFromWaypoints
+%
+
+% Disclamer:
+%   SPDX-License-Identifier: GPL-2.0-only
+%
+%   Copyright (C) 2020-2022 Fabian Guecker
+%   Copyright (C) 2022 TU Braunschweig, Institute of Flight Guidance
+% *************************************************************************
+
+if(traj.polynomial_degree ~= 5)
+    error('Polynominal order is not 5.')
+end
+
+% return values
+section_idx = 1;
+error_sqr = inf;
+t = 0;
+
+% aircraft's position
+xf = position(1);
+yf = position(2);
+zf = position(3);
+
+% Section Range
+first_checked_section = 1;
+last_checked_section = traj.num_sections_set;
+
+% poly-vector
+P = zeros(1,10);
+
+% Precalculation of subdiagonal matrix for schur decomposition
+A5 = diag(ones(8,1),-1);
+
+% Iterate through all relevant sections
+for k = first_checked_section:last_checked_section
+    
+    % Polynomial coefficents
+    x = traj.sections(k).pos_x';
+    y = traj.sections(k).pos_y';
+    z = traj.sections(k).pos_z';
+         
+    % Calculate first derivative of the squared distance
+    P(1) = 5*x(1)^2 + 5*y(1)^2 + 5*z(1)^2;
+    P(2) = 9*x(1)*x(2) + 9*y(1)*y(2) + 9*z(1)*z(2);
+    P(3) = 4*x(2)^2 + 4*y(2)^2 + 4*z(2)^2 + 8*x(1)*x(3) + 8*y(1)*y(3) + 8*z(1)*z(3);
+    P(4) = 7*x(1)*x(4) + 7*x(2)*x(3) + 7*y(1)*y(4) + 7*y(2)*y(3) + 7*z(1)*z(4) + 7*z(2)*z(3);
+    P(5) = 3*x(3)^2 + 3*y(3)^2 + 3*z(3)^2 + 6*x(1)*x(5) + 6*x(2)*x(4) + 6*y(1)*y(5) + 6*y(2)*y(4) + 6*z(1)*z(5) + 6*z(2)*z(4);
+    P(6) = 5*x(1)*x(6) + 5*x(2)*x(5) + 5*x(3)*x(4) - 5*x(1)*xf + 5*y(1)*y(6) + 5*y(2)*y(5) + 5*y(3)*y(4) - 5*y(1)*yf + 5*z(1)*z(6) + 5*z(2)*z(5) + 5*z(3)*z(4) - 5*z(1)*zf;
+    P(7) = 2*x(4)^2 + 2*y(4)^2 + 2*z(4)^2 + 4*x(2)*x(6) + 4*x(3)*x(5) - 4*x(2)*xf + 4*y(2)*y(6) + 4*y(3)*y(5) - 4*y(2)*yf + 4*z(2)*z(6) + 4*z(3)*z(5) - 4*z(2)*zf;
+    P(8) = 3*x(3)*x(6) + 3*x(4)*x(5) - 3*x(3)*xf + 3*y(3)*y(6) + 3*y(4)*y(5) - 3*y(3)*yf + 3*z(3)*z(6) + 3*z(4)*z(5) - 3*z(3)*zf;
+    P(9) = x(5)^2 + y(5)^2 + z(5)^2 + 2*x(4)*x(6) - 2*x(4)*xf + 2*y(4)*y(6) - 2*y(4)*yf + 2*z(4)*z(6) - 2*z(4)*zf;
+    P(10) = x(5)*x(6) - x(5)*xf + y(5)*y(6) - y(5)*yf + z(5)*z(6) - z(5)*zf;
+    
+    %% Solve eigenvalue problem with companion matrix to find the roots of P
+    
+    % make sure first entry is not zero (prevent division by zero)
+    if(abs(P(1)) <= eps(P(1)))
+        P(1) = eps(P(1));
+    end
+    
+    % build the companion matrix
+    A = A5;
+    A(1,:) = -P(2:10)./P(1);
+    
+    % solve eigenvalue problem with schur decomposition
+    Schur_mat = schur(A);
+    
+    % The diagonal elements hold the eigenvalues, each of them is a
+    % root of P. It is a cadidate for the segments minimum if it is
+    % real and satisfies the condition 0 <= t <= 1. Check also the both
+    % edges of the segment.
+    
+    T = [Schur_mat(1,1); Schur_mat(2,2); Schur_mat(3,3);
+        Schur_mat(4,4); Schur_mat(5,5); Schur_mat(6,6);
+        Schur_mat(7,7); Schur_mat(8,8); Schur_mat(9,9);
+        0; 1];
+    
+    %% Calculate the squared error for every candidate between 0 and  1
+    
+    t_values = zeros(1,6);
+    curr_pos = zeros(1,3);
+    
+    for i=1:11
+        T_i = T(i);
+        if (T_i <= 1.0) && (T_i >= 0.0)
+            
+            % Loop unrolling for calculation of t, t^2, t^3, ...
+            t_values(6) = 1;
+            t_values(5) = T_i;
+            t_values(4) = t_values(5) * T_i;
+            t_values(3) = t_values(4) * T_i;
+            t_values(2) = t_values(3) * T_i;
+            t_values(1) = t_values(2) * T_i;
+            
+            % calculate the distance in all three dimensions
+            curr_pos(1) = t_values * x - xf;
+            curr_pos(2) = t_values * y - yf;
+            curr_pos(3) = t_values * z - zf;
+            
+            % calculate the squared error
+            curr_error = sum(curr_pos .* curr_pos);
+            
+            % check if current error is smaller then the smallest found 
+            if(curr_error < error_sqr)
+                t = T_i;
+                section_idx = k;
+                error_sqr = curr_error;
+            end
+        end
+    end
+    
+end
+
+end

--- a/utilities/algorithms/integralSimpson.m
+++ b/utilities/algorithms/integralSimpson.m
@@ -1,0 +1,54 @@
+function [ Q ] = integralSimpson( func, A, B, steps)
+
+% integralSimpson Numerically evaluate integral with Simpson quadrature.
+%   Q = integralSimpson(FUN, A, B, steps) attempts to approximate the 
+%   integral of scalar-valued function FUN from A to B. The interval given 
+%   by A and B is equally spaced with a constant stepsize.
+%
+% Inputs:
+%
+%   func            function handle Y = FUN(X) should accept a scalar
+%                   argument X and return a scalar argument Y.
+%                   (scalar function handle)
+%
+%   A               lower bound for integration
+%                   (scalar)
+%
+%   B               Upper bound for integration
+%                   (scalar)
+%
+%   steps           Number of subsegments to evaluate
+%                   (integer)
+
+%
+% Outputs:
+%
+%   Q               integration result
+%
+% Syntax:
+%   [ Q ] = integralSimpson( func, A, B, steps)
+%
+
+% Disclamer:
+%   SPDX-License-Identifier: GPL-2.0-only
+% 
+%   Copyright (C) 2020-2022 Fabian Guecker
+%   Copyright (C) 2022 TU Braunschweig, Institute of Flight Guidance
+% *************************************************************************
+
+t = A; 
+Q = 0;
+step = (B-A) / steps;
+step_1_2 = 0.5 * step;
+
+Q = 0.5 * func(A);
+Q = Q - 0.5 * func(B);
+
+for i = 1:steps
+    t = t + step;
+    Q = Q + 2.0 * func(t - step_1_2) + func(t);   
+end
+
+Q = (1/3) * step * Q;
+
+end

--- a/utilities/algorithms/polyVal.m
+++ b/utilities/algorithms/polyVal.m
@@ -1,0 +1,45 @@
+function [y] = polyVal(p, x)
+%POLYVAL Evaluate polynomial.
+%   Y = POLYVAL(P,X) returns the value of a polynomial P evaluated at X. P
+%   is a vector of length N+1 whose elements are the coefficients of the
+%   polynomial in descending powers.
+%
+%       Y = P(1)*X^N + P(2)*X^(N-1) + ... + P(N)*X + P(N+1)
+%
+% Inputs:
+%
+%   p               coefficients of the polynomial in descending powers
+%                   (vector 1xN)
+%
+%   x               points X, where the polynomial P is evaluated  
+%                   (vector 1xM)
+%
+% Outputs:
+%
+%   y               values of the evaluated points X of the polynomial P 
+%                   (vector 1xM)
+%
+% Syntax:
+%   [ y ] = polyVal(p, x)
+%
+
+% Disclamer:
+%   SPDX-License-Identifier: GPL-2.0-only
+% 
+%   Copyright (C) 2020-2022 Fabian Guecker
+%   Copyright (C) 2022 TU Braunschweig, Institute of Flight Guidance
+% *************************************************************************
+
+nc = length(p);
+siz_x = size(x);
+y = zeros(siz_x);
+
+if nc > 0
+    y(:) = p(1);
+end
+
+for i = 2:nc
+    y = x .* y + p(i);
+end
+
+end


### PR DESCRIPTION
- Changed polyval to custom polyVal function, because there was an "Werror=maybe-uninitialized" error while compiling with ArduPilots default settings.

- Added special trajGetMatch function for polynomial degree 5 to use Schur decomposition and some other runtime optimizations

- Replaced quadgk by Simpson's rule, this saved a huge amount of ram and flash.

- Resolve #1: Use the latest HotFix in mutils for a problem of trajectoryBus generations, because in the generated C++ code the variable sections of the trajectoryBus were also defined by the type sections. This caused a compiler error that has been fixed.
