### PR TITLE
Fix trajFromWaypointsIterative for zero waypoints and improve speed

### DIFF
--- a/control/trajectory/trajFromWaypointsIterative.m
+++ b/control/trajectory/trajFromWaypointsIterative.m
@@ -101,9 +101,13 @@ if (trig_update == 1) && (state == 0) && (axis_sel == 0)
     traj_valid = zeros(1, superiorfloat(state_vec));
     traj = traj_empty;
     
-    % Select the first axis and set state to zero
-    axis_sel = ones(1, superiorfloat(state_vec));
-    state    = zeros(1, superiorfloat(state_vec)); 
+    % check waypoints are valid   
+    if trajValidateWaypoints(waypoints, num_wp, cycle)
+        
+        % Select the first axis and set state to zero
+        axis_sel = ones(1, superiorfloat(state_vec));
+        state    = zeros(1, superiorfloat(state_vec)); 
+    end
     
 elseif (axis_sel >= 1) && (axis_sel <= 3)
     
@@ -126,6 +130,9 @@ elseif (axis_sel >= 1) && (axis_sel <= 3)
         uvwxb(1:b_size, 4) = w;
         uvwxb(1:b_size, 5) = x;   
         AnormAlfaRhoPhi = [Anorm; alfa; rhobar; phibar];
+        
+        % Calculate inital error
+        residuum = norm( A(x,1) - b );
         
     % States above zero mean iterating
     elseif state < 1000
@@ -158,10 +165,11 @@ elseif (axis_sel >= 1) && (axis_sel <= 3)
         state = state + 1;
         
         % Calculate residuum
+        residuum_last = residuum;
         residuum = norm( A(x,1) - b );
         
         % Check if finished
-        if( residuum < 1e-3)
+        if (residuum < 1e-3) || (residuum_last < residuum)
             if strcmp(datatype, 'single')
                 state = single(1000);
             else

--- a/control/trajectory/trajValidateWaypoints.m
+++ b/control/trajectory/trajValidateWaypoints.m
@@ -1,0 +1,45 @@
+function is_valid = trajValidateWaypoints(waypoints, num_wp, cycle)
+% trajValidateWaypoints checks that the waypoints form a valid trajectory
+%   The function returns true if the given waypoints form a valid
+%   trajectory, otherwise it returns false
+%
+% Inputs:
+%   points          trajectory waypoints [x; y; z] in local geodetic
+%                   coordinate system
+%                   (3xN vector), in m
+%
+%   num_wp          the total number of waypoints
+%                   (scalar), dimensionless
+%
+%   cycle           enable automatic repetition of the given course
+%
+% Outputs:
+%
+%   valid           hold result if the waypoints form a valid trajectory
+%                   (logical), dimensionless
+%
+% Syntax:
+%   is_valid = trajValidateWaypoints(traj, waypoints, degree, cycle)
+%
+% See also: trajInit
+%
+
+% Disclamer:
+%   SPDX-License-Identifier: GPL-2.0-only
+% 
+%   Copyright (C) 2020-2022 Fabian Guecker
+%   Copyright (C) 2022 TU Braunschweig, Institute of Flight Guidance
+% *************************************************************************
+
+% Set default value to false, perform checks to sort out errors.
+% If the end of function is reached, no errors occured.
+is_valid = false;
+
+% At least 3 Waypoints are needed for a course
+if num_wp < 3
+    return;
+end
+ 
+is_valid = true;
+
+end


### PR DESCRIPTION
When the number of waypoint was zero, the function trajFromWaypointsIterative crashed cause of an array bound violation.

A new function trajValidateWaypoints is introduced to check if the given waypoints are enough for the requested type of trajectory (cycle option) and maybe fulfill some other conditions in the future, e.g. points are not equal.

For improving calculation time, the residuum of ||Ax-b|| is now calculated before the first iteration lsqr. If the residuum starts to grow, the lsqr iteration is finished an the loop can be breaked.