### PR TITLE
Update READMEs, add workaround for WSL2-Windows UDP connection issue

### DIFF
--- a/control/autopilots/LindiCopter/README.md
+++ b/control/autopilots/LindiCopter/README.md
@@ -52,8 +52,7 @@ Using the ArduPilot custom controller interface means, that the ArduPilot EKF is
 With the ArduPilot custom controller interface you can perform software in the loop simulations as well as flight tests.
 
 As a starting point there is an example in [LADAC-Examples](https://github.com/iff-gsc/LADAC-Examples).  
-You can prepare the C++ Code Generation by running:  
-[init_Arducopter_MinnieLindiCopter](Copter/Minnie/ArduPilot_implementation/init_Arducopter_MinnieLindiCopter.m).
+You can prepare the C++ Code Generation by running [init_Arducopter_MinnieLindiCopter](https://github.com/iff-gsc/LADAC-Examples/blob/main/Copter/Minnie/ArduPilot_implementation/init_Arducopter_MinnieLindiCopter.m).
 
 **Flight Mode Info**  
 - Loiter: Note that the Loiter flight mode currently runs in NED frame.

--- a/utilities/interfaces_external_programs/ArduPilot_SITL/README.md
+++ b/utilities/interfaces_external_programs/ArduPilot_SITL/README.md
@@ -8,7 +8,7 @@ For more information about the ArduPilot SITL interfaces take a look at the
 the [ArduPilot source code](https://github.com/ArduPilot/ardupilot/blob/master/libraries/SITL/SIM_Gazebo.h),
 the [implementation of SwiftGust plugin](https://github.com/SwiftGust/ardupilot_gazebo)
 or the [implementation of khancyr plugin](https://github.com/khancyr/ardupilot_gazebo).  
-Note that the Gazebo interface does not support all kind of sensors yet while the Custom Simulink Interface provides rangefinder sensors and could be easily extended about other sensors.
+Note that the Gazebo interface does not support all kind of sensors yet while the Custom Simulink Interface provides rangefinder sensors and can easily be extended to include other sensors.
 
 
 ## Motivation
@@ -36,13 +36,13 @@ The parameters of the spiral can be adjusted by a parameter file.
 
 1. Open the MATLAB/Simulink test trajectory simulation
    1. Open MATLAB/Simulink.
-   2. Run the parameters file init_example_SITL.m.
-   3. Open the Simulink file example_SITL.slx.
+   2. Run the parameters file [init_exampleSITL.m](/utilities/interfaces_external_programs/ArduPilot_SITL/init_exampleSITL.m).
+   3. Open the Simulink file [example_SITL.slx](/utilities/interfaces_external_programs/ArduPilot_SITL/example_SITL.slx).
    4. Run the Simulink model. The green switch should activate "apply zeros"
         in order to simulate a vehicle standing on the ground.
 
 2. Prepare ArduPilot SITL
-   1. Run the SITL **in Gazebo mode** (`--model=gazebo`) from command line specifying the desired parameter, e.g. (you can replace `plane` with `copter` etc.):
+   1. Run the SITL **in Gazebo mode** (`--model=gazebo`) from command line specifying the desired parameter, e.g. (you can replace `plane` with `quad` etc.):
       ``````
       sim_vehicle.py -v ArduPlane -f plane --model=gazebo
       ``````
@@ -53,10 +53,10 @@ The parameters of the spiral can be adjusted by a parameter file.
 
 3. Get visual feedback with ground control station:  
    Run a ground control station software like Mission Planner or QGroundControl
-        and establish a connection with the SITL
+        and establish a connection with the SITL.
 
 4. Activate the test trajectory simulation
-   1. In the running Simulink model example_SITL.slx double-click the green switch
+   1. In the running Simulink model [example_SITL.slx](/utilities/interfaces_external_programs/ArduPilot_SITL/example_SITL.slx) double-click the green switch
         to activate "apply spiral".
    2. If you want to start a new test trajectory simulation, you have to stop the
         current simulation and repeat the whole procedure.
@@ -98,8 +98,8 @@ The following section describes the custom Debug Message to SIMULINK.
         
 
 3. Customizing the Interface\
-        -To change the data send by the Interface you may change the content of the sendto message in mode_custom
-        -The receiving block needs to be changed accordingly.
+        To change the data sent by the Interface you may change the content of the sendto message in mode_custom.  
+        The receiving block needs to be changed accordingly.
     
 * known issues\
       Due to the additional message expected by SIMULINK and the according Blocking time the simulation slows down significantly until mode_custom is enabled. 

--- a/utilities/interfaces_external_programs/ArduPilot_custom_controller/README.md
+++ b/utilities/interfaces_external_programs/ArduPilot_custom_controller/README.md
@@ -10,7 +10,7 @@ If you design your controllers for an existing vehicle, you have to implement yo
 Since the controller is only a (small) part of the software running on the electronic control unit, it might be beneficial to implement the controller in an existing software like ArduPilot. 
 ArduPilot supports different boards and sensors, it allows communication via MAVLink and also provides a state estimator (EKF) if needed. 
 Moreover, you can perform software in the loop (SITL) simulations and keep standard ArduPilot flight modes if you want.
-Here, the implementation of your MATLAB/Simulink controller in ArduPilot is discribed.
+Here, the implementation of your MATLAB/Simulink controller in ArduPilot is described.
 
 ## Installation
 
@@ -20,11 +20,13 @@ Here, the implementation of your MATLAB/Simulink controller in ArduPilot is disc
   - ArduCopter 4.2.0
     ```
     git clone -b Copter-Matlab-4.2.0-dev https://github.com/ybeyer/ardupilot
+    cd ardupilot
     git submodule update --init --recursive
     ```
   - ArduPlane 4.3.0
     ```
     git clone -b Plane-Matlab-4.3 https://github.com/ybeyer/ardupilot
+    cd ardupilot
     git submodule update --init --recursive
 - These instructions assume that you have a basic understanding of ArduPilot and the ArduPilot SITL. Please also note the [ArduPilot SITL interface of LADAC](../ArduPilot_SITL#readme).
 
@@ -55,7 +57,7 @@ Note that the steps are slightly different for ArduCopter and ArduPlane.
    - Terminate the simulation with `Cntrl+C`.
    - You can now review the [logs](https://ardupilot.org/dev/docs/using-sitl-for-ardupilot-testing.html). The actuator commands should be equal to the outputs of the MATLAB/Simulink dummy controller.
    Moreover, there should be a `ML1` struct which contains the custom logs of the MATLAB/Simulink dummy controller.
-2. Upload the code on your board.  
+3. Upload the code to your board.  
    - You can build the code for supported boards and upload it according to the [Building ArduPilot documentation](https://github.com/ArduPilot/ardupilot/blob/master/BUILD.md).
    - For example, if your board is a Pixhawk 1, use the following commands:
      ```
@@ -64,7 +66,7 @@ Note that the steps are slightly different for ArduCopter and ArduPlane.
      ./waf --upload copter
      ```
      (Note that you have to replace `copter` with `plane` if you want to build ArduPlane.)
-3. Test the MATLAB/Simulink controller in flight tests **(CAUTION: THIS MIGHT BE DANGEROUS, PLEASE ASSURE SAFETY ARRANGEMENTS!)**.
+4. Test the MATLAB/Simulink controller in flight tests **(CAUTION: THIS MIGHT BE DANGEROUS, PLEASE ASSURE SAFETY ARRANGEMENTS!)**.
    - Only do flight tests after careful and comprehensive [SITL tests](../ArduPilot_SITL#readme).
    - Only do flight tests at dedicated terrain.
    - Only do flight tests if you are sure that you can deactivate the MATLAB/Simulink controller at all times.
@@ -93,15 +95,15 @@ Take a look at the Simulink models [`ArduCopter_TemplateController`](ArduCopter_
 They contain the dummy controller in the middle.
 On the left and on the right, there are interfaces to the ArduPilot fork.
 In this case, the dummy controller sends constant values to the actuators and it logs some signals.  
-To get to run your MATLAB/Simulink controller in ArduPilot you have to generate C++ code from your Simulink model and you must copy it inside the ArduPilot fork.
+To get your MATLAB/Simulink controller to run in ArduPilot you need to generate C++ code from your Simulink model and copy it into the ArduPilot fork.
 
-1. Make a copy of one of the `Ardu<Copter/Plane>_TemplateController` Simulink files, replace the *dummy test controller* with your own controller block and connect the inputs and outputs with the interface blocks to ArduPilot (*Actuator muxer*, *log muxer* etc.). The interface blocks are provided by the Simulink library [`ardupilot_custom_controller_lib`](ardupilot_custom_controller_lib.slx). You have to initialize the Simulink bus objects in the first place in Matlab:
+1. Make a copy of one of the `Ardu<Copter/Plane>_TemplateController` Simulink files, replace the *dummy test controller* with your own controller block and connect the inputs and outputs with the interface blocks to ArduPilot (*Actuator muxer*, *log muxer* etc.). The interface blocks are provided by the Simulink library [`ardupilot_custom_controller_lib`](ardupilot_custom_controller_lib.slx). You must first initialise the Simulink bus objects in MATLAB:
     ```
     ardupilotCreateInputBuses
     ```
 2. Generate C++ code from the Simulink file (click top right button "Build Model"): https://de.mathworks.com/help/dsp/ug/generate-c-code-from-simulink-model.html  
   Note that floating points should be 32-bit. This is assured in the Simulink template files because the following parameters were set: `set_param(gcs, 'DefaultUnderspecifiedDataType', 'single')` and `set_param(gcs, 'DataTypeOverride', 'Single','DataTypeOverrideAppliesTo','Floating-point')`
-3. You need only four files of the generated code: `MatlabController.cpp`, `MatlabController.h`, `MatlabController_data.cpp` and `rtwtypes.h`.
+3. You only need four files of the generated code: `MatlabController.cpp`, `MatlabController.h`, `MatlabController_data.cpp` and `rtwtypes.h`.
    Store these files in one folder and copy the content into your local ArduPilot repository.  
    **ArduCopter:**
      ```
@@ -111,13 +113,13 @@ To get to run your MATLAB/Simulink controller in ArduPilot you have to generate 
      ```
      cp -rf <your_source_folder>/. <path_to_ardupilot>/libraries/AP_Common/
      ```
-4. You should now be able to compile the modified ArduPilot project and use flight mode 26 (ArduCopter) or mode 25 (ArduPlane).  
+4. You should now be able to compile the modified ArduPilot project and use flight mode 29 (ArduCopter) or mode 26 (ArduPlane).  
 Note that it is probably required to delete the `build` folder in your local ArduPilot repository or to perform a `./waf clean`.
 
 
 ## Contribute
 
-If you generally want to understand how the interface works or if you want to use a different ArduPilot commit, you may have to look inside the ArduPilot code. 
+If you want to understand in general how the interface works, or if you want to use a different ArduPilot commit, you may need to look into the ArduPilot code. 
 This is a guide of how to adjust the code.
 
 For each step there is a git commit in the ArduPilot fork. 


### PR DESCRIPTION
Updated READMEs:
- Autopilot LindiCopter
- Implement your MATLAB/Simulink controller
- ArduPilot SITL interfaces for Simulink

Additionally, in the ArduPilot SITL interfaces for Simulink README a workaround has been added for the UDP connection issue when using ArduPilot SITL under WSL2 and MATLAB/Simulink under Windows.