### PR TITLE
ArduPilot custom controller: Rename a_Kb, a_Kg -> a_b, a_g

### DIFF
--- a/utilities/interfaces_external_programs/ArduPilot_custom_controller/ardupilotCreateInputBuses.m
+++ b/utilities/interfaces_external_programs/ArduPilot_custom_controller/ardupilotCreateInputBuses.m
@@ -46,12 +46,14 @@ measure.EulerAngles = zeros(3,1);
 % quaternion from NED to FRD frame (predicted and thus almost without
 % delay)
 measure.q_bg        = euler2Quat(measure.EulerAngles);
-% measured acceleration represented in NED frame, in m/s^2 (x and y
-% component almost without delay; z component seems to be delayed by
-% INS_ACCEL_FILTER)
-measure.a_Kg        = zeros(3,1);
+% measured acceleration represented in NED frame, in m/s^2 (delayed by
+% INS_ACCEL_FILTER; contains the acceleration due to gravity and is at
+% standstill [0;0;-9.81])
+measure.a_g         = zeros(3,1);
 % measured acceleration represented in FRD frame, in m/s^2
-measure.a_Kb = zeros(3,1);
+% (contains the acceleration due to gravity and is at standstill
+% M_bg*[0;0;-9.81], where M_bg is the rotation matrix from g to b frame)
+measure.a_b         = zeros(3,1);
 % velocity of FRD frame relative to the earth represented in FRD frame, in
 % m/s (predicted and thus almost without delay)
 measure.V_Kg        = zeros(3,1);


### PR DESCRIPTION
The choice of the variable names a_Kb and a_Kg were unfavorable. The variables are the acceleration in the body-fixed coordinate system b and earth-fixed coordinate system g. The index K indicates a motion from the body relative to the earth. However, the variables a_Kg and a_Kb are defined to represent the acceleration measured by the IMU and thus contain the gravitational acceleration. To avoid confusion in the future, the "K"s in the variable names have been removed. Moreover, the comments in the functions were supplemented, so that the definition of the variables becomes clear.
Unfortunately, this change will cause errors in old projects.